### PR TITLE
Migrate to AGP 9

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("kotlin-android")
     id("com.android.application")
     id("com.google.devtools.ksp")
     id("dagger.hilt.android.plugin")
@@ -35,6 +34,7 @@ android {
         release {
             minifyEnabled = false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
         }
     }
     compileOptions {
@@ -67,18 +67,18 @@ kotlin {
     }
 }
 
-androidComponents {
-    def date = new Date()
-    def formattedDate = date.format('dd.MM.yyyy hh.mm a')
-
-    onVariants(selector().all()) { variant ->
-        variant.outputs.forEach { output ->
-            def variantName = variant.buildType
-            def versionName = variant.outputs.first().versionName.get()
-            output.outputFileName.set("app_${variantName}_v${versionName}_${formattedDate}.apk")
-        }
-    }
-}
+//androidComponents {
+//    def date = new Date()
+//    def formattedDate = date.format('dd.MM.yyyy hh.mm a')
+//
+//    onVariants(selector().all()) { variant ->
+//        variant.outputs.forEach { output ->
+//            def variantName = variant.buildType
+//            def versionName = variant.outputs.first().versionName.get()
+//            output.outputFileName.set("app_${variantName}_v${versionName}_${formattedDate}.apk")
+//        }
+//    }
+//}
 
 hilt {
     enableAggregatingTask = true

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,12 @@
 plugins {
-    id("com.android.library") version "8.13.1" apply false
-    id("com.android.application") version "8.13.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.21" apply false
-    id("com.google.devtools.ksp") version "2.3.3" apply false
-    id("com.google.dagger.hilt.android") version "2.57.2" apply false
-    id("androidx.navigation.safeargs") version "2.9.6" apply false
+    id("com.android.library") version "9.1.0" apply false
+    id("com.android.application") version "9.1.0" apply false
+    id("com.google.devtools.ksp") version "2.3.6" apply false
+    id("com.google.dagger.hilt.android") version "2.59.2" apply false
+    id("androidx.navigation.safeargs") version "2.9.7" apply false
     id("com.google.gms.google-services") version "4.4.4" apply false
     id("com.google.firebase.crashlytics") version "3.0.6" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.2.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.3.20" apply false
 }
 
 // Define shared configuration properties

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("kotlin-android")
     id("com.android.library")
     id("com.google.devtools.ksp")
     id("dagger.hilt.android.plugin")
@@ -43,11 +42,11 @@ android {
     namespace = "dev.atick.core"
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget = JvmTarget.JVM_21
-    }
-}
+//kotlin {
+//    compilerOptions {
+//        jvmTarget = JvmTarget.JVM_21
+//    }
+//}
 
 hilt {
     enableAggregatingTask = true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,8 @@
+#Wed Apr 01 09:57:39 AST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/movesense/build.gradle
+++ b/movesense/build.gradle
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("kotlin-android")
     id("com.android.library")
     id("com.google.devtools.ksp")
     id("dagger.hilt.android.plugin")

--- a/network/build.gradle
+++ b/network/build.gradle
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.library")
-    id("kotlin-android")
     id("com.google.devtools.ksp")
     id("dagger.hilt.android.plugin")
 }

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.library")
-    id("kotlin-android")
     id("com.google.devtools.ksp")
     id("dagger.hilt.android.plugin")
 }


### PR DESCRIPTION
This pull request primarily updates the Gradle version and makes several adjustments to the Gradle build scripts across multiple modules. The most significant changes include upgrading the Gradle wrapper, cleaning up plugin declarations, and commenting out or modifying custom build script logic.

**Build tooling and configuration updates:**

* Upgraded the Gradle wrapper from version 9.2.1 to 9.3.1 and added the SHA256 checksum for the new distribution in `gradle-wrapper.properties`.
* Removed the `kotlin-android` plugin from the `plugins` block in all module `build.gradle` files (`app`, `core`, `movesense`, `network`, `storage`). [[1]](diffhunk://#diff-51a0b488f963eb0be6c6599bf5df497313877cf5bdff3950807373912ac1cdc9L4) [[2]](diffhunk://#diff-8661f4ba56dd608a0331a1b951fcc910c80ddd53de7dec30cdf6c0e773cab6d0L4) [[3]](diffhunk://#diff-f06949e8305c8c5f54925defcf2826121e63d16b4ffdb77c8c110c535ca39990L4) [[4]](diffhunk://#diff-b7fbe2e15184b5a1328ed60a9ac5f8292302fab0bfb383bc05ee44ffeafe90c2L5) [[5]](diffhunk://#diff-f93b3f3acff682f1df0253c3ac502115cb986abdbdef8dcd2facf2d491442b12L5)

**Build script logic changes:**

* Commented out the custom `androidComponents` block in `app/build.gradle` that previously set custom APK output filenames based on variant and date.
* Commented out the explicit Kotlin JVM target configuration in `core/build.gradle`.

**Signing configuration:**

* Updated the `release` build type in `app/build.gradle` to use the `debug` signing configuration, likely to simplify signing during development.